### PR TITLE
Add ability to have custom pointer for `useFluid`

### DIFF
--- a/packages/use-shader-fx/src/hooks/types/index.ts
+++ b/packages/use-shader-fx/src/hooks/types/index.ts
@@ -23,7 +23,7 @@ export type HooksReturn<T, O> = [
     * @param props RootState
     * @param params params of hooks
     */
-   (props: RootState, updateParams?: T) => THREE.Texture,
+   (props: RootState, updateParams?: T, customPointer?: THREE.Vector2) => THREE.Texture,
    /**
     * Function to update params. It can be used for performance control, etc.
     * @param params params of hooks

--- a/packages/use-shader-fx/src/hooks/useFluid/index.ts
+++ b/packages/use-shader-fx/src/hooks/useFluid/index.ts
@@ -62,7 +62,8 @@ export const useFluid = ({
    size,
    dpr,
    samples = 0,
-}: HooksProps): HooksReturn<FluidParams, FluidObject> => {
+   pointer: _pointer,
+}: HooksProps & {pointer?: THREE.Vector2}): HooksReturn<FluidParams, FluidObject> => {
    const scene = useMemo(() => new THREE.Scene(), []);
    const [materials, setMeshMaterial] = useMesh({ scene, size, dpr });
    const camera = useCamera(size);
@@ -129,9 +130,11 @@ export const useFluid = ({
             );
          });
 
+         // use default viewport pointer if _pointer is not provided
+         const pointerValue = _pointer ?? pointer;
          // update splatting
          const { currentPointer, diffPointer, isVelocityUpdate, velocity } =
-            updatePointer(pointer);
+            updatePointer(pointerValue);
          if (isVelocityUpdate) {
             updateVelocityFBO(gl, ({ read }) => {
                setMeshMaterial(materials.splatMaterial);

--- a/packages/use-shader-fx/src/hooks/useFluid/index.ts
+++ b/packages/use-shader-fx/src/hooks/useFluid/index.ts
@@ -62,8 +62,7 @@ export const useFluid = ({
    size,
    dpr,
    samples = 0,
-   pointer: _pointer,
-}: HooksProps & {pointer?: THREE.Vector2}): HooksReturn<FluidParams, FluidObject> => {
+}: HooksProps): HooksReturn<FluidParams, FluidObject> => {
    const scene = useMemo(() => new THREE.Scene(), []);
    const [materials, setMeshMaterial] = useMesh({ scene, size, dpr });
    const camera = useCamera(size);
@@ -91,7 +90,7 @@ export const useFluid = ({
    const [params, setParams] = useParams<FluidParams>(FLUID_PARAMS);
 
    const updateFx = useCallback(
-      (props: RootState, updateParams?: FluidParams) => {
+      (props: RootState, updateParams?: FluidParams, customPointer?:THREE.Vector2) => {
          const { gl, pointer, clock, size } = props;
 
          updateParams && setParams(updateParams);
@@ -130,8 +129,14 @@ export const useFluid = ({
             );
          });
 
-         // use default viewport pointer if _pointer is not provided
-         const pointerValue = _pointer ?? pointer;
+         //Transform custom pointer from mesh [0,1] to [-1,1]
+         const transformedCustomPointer = customPointer ? customPointer
+				.clone()
+				.multiplyScalar(2)
+				.subScalar(1) : undefined;
+         // use default viewport pointer if customPointer is not provided
+         const pointerValue = transformedCustomPointer ?? pointer;
+
          // update splatting
          const { currentPointer, diffPointer, isVelocityUpdate, velocity } =
             updatePointer(pointerValue);


### PR DESCRIPTION
This PR adds the ability to have custom pointer coordinates to `useFluid`. Ideally, this could be used to have pointer position relative to the mesh UV coordinate, make it possible to apply `useFluid` effect to mesh material in the scene.

This is planned to solve this issue: https://github.com/takuma-hmng8/use-shader-fx/issues/62